### PR TITLE
🐛 Add animation url to metaplex data

### DIFF
--- a/Runtime/codebase/data/MetaplexData.cs
+++ b/Runtime/codebase/data/MetaplexData.cs
@@ -16,6 +16,7 @@ namespace Solana.Unity.SDK.Nft
         public string name;
         public string description;
         public string previewUrl;
+        public string animation_url;
         public string image;
         public Attributes[] attributes;
         public Properties properties;


### PR DESCRIPTION


| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready|Bug|No | [Link](https://github.com/garbles-labs/Solana.Unity-SDK/issues/28) |

## Problem

_What problem are you trying to solve?_
When parsing nft data the animation url was missingg

## Solution

_How did you solve the problem?_
Added the field to the metaplex json data. 

