### PR TITLE
Add support for Phantom signMessage method

### DIFF
--- a/Runtime/Plugins/Phantom.jslib
+++ b/Runtime/Plugins/Phantom.jslib
@@ -47,13 +47,12 @@ mergeInto(LibraryManager.library, {
     ExternSignMessage: async function (message, callback) {
         if ('phantom' in window && window.phantom != null && window.phantom.solana != null) {
             try {
-               const messageString = UTF8ToString(message);
-               const encodedMessage = new TextEncoder().encode(messageString);
+               const messageBase64String = UTF8ToString(message);
+               const messageBytes = Uint8Array.from(atob(messageBase64String), (c) => c.charCodeAt(0));
                const signedMessage = await window.phantom.solana.request({
                   method: 'signMessage',
                   params: {
-                     message: encodedMessage,
-                     display: "utf8",
+                     message: messageBytes
                   },
                });
                 console.log(signedMessage);

--- a/Runtime/Plugins/Phantom.jslib
+++ b/Runtime/Plugins/Phantom.jslib
@@ -43,4 +43,32 @@ mergeInto(LibraryManager.library, {
         }
     },
 
+
+    ExternSignMessage: async function (message, callback) {
+        if ('phantom' in window && window.phantom != null && window.phantom.solana != null) {
+            try {
+               const messageString = UTF8ToString(message);
+               const encodedMessage = new TextEncoder().encode(messageString);
+               const signedMessage = await window.phantom.solana.request({
+                  method: 'signMessage',
+                  params: {
+                     message: encodedMessage,
+                     display: "utf8",
+                  },
+               });
+                console.log(signedMessage);
+                var sign = signedMessage.signature;
+                var lenSign = lengthBytesUTF8(sign) + 1;
+                var strPtr = _malloc(lenSign);
+                stringToUTF8(sign, strPtr, lenSign);
+                Module.dynCall_vi(callback, strPtr);
+            } catch (err) {
+                window.alert('Phantom error: ' + err.message);
+                console.error(err.message);
+            }
+        } else {
+            window.alert('Please install phantom browser extension.');
+        }
+    },
+    
 });

--- a/Runtime/codebase/IWalletBase.cs
+++ b/Runtime/codebase/IWalletBase.cs
@@ -89,8 +89,14 @@ namespace Solana.Unity.SDK
         /// </summary>
         /// <param name="transaction"></param>
         /// <returns></returns>
-
         Task<Transaction> SignTransaction(Transaction transaction);
+
+        /// <summary>
+        /// Sign a message
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        Task<byte[]> SignMessage(string message);
 
         /// <summary>
         /// Sign and send a transaction

--- a/Runtime/codebase/IWalletBase.cs
+++ b/Runtime/codebase/IWalletBase.cs
@@ -96,7 +96,7 @@ namespace Solana.Unity.SDK
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
-        Task<byte[]> SignMessage(string message);
+        Task<byte[]> SignMessage(byte[] message);
 
         /// <summary>
         /// Sign and send a transaction

--- a/Runtime/codebase/InGameWallet.cs
+++ b/Runtime/codebase/InGameWallet.cs
@@ -71,6 +71,12 @@ namespace Solana.Unity.SDK
             return Task.FromResult(transaction);
         }
 
+        public override Task<byte[]> SignMessage(string message)
+        {
+            var encodedMessage = Encoding.UTF8.GetBytes(message);
+            return Task.FromResult(Account.Sign(encodedMessage));
+        }
+
         private static string LoadPlayerPrefs(string key)
         {
             return PlayerPrefs.GetString(key);

--- a/Runtime/codebase/InGameWallet.cs
+++ b/Runtime/codebase/InGameWallet.cs
@@ -71,10 +71,9 @@ namespace Solana.Unity.SDK
             return Task.FromResult(transaction);
         }
 
-        public override Task<byte[]> SignMessage(string message)
+        public override Task<byte[]> SignMessage(byte[] message)
         {
-            var encodedMessage = Encoding.UTF8.GetBytes(message);
-            return Task.FromResult(Account.Sign(encodedMessage));
+            return Task.FromResult(Account.Sign(message));
         }
 
         private static string LoadPlayerPrefs(string key)

--- a/Runtime/codebase/PhantomWallet.cs
+++ b/Runtime/codebase/PhantomWallet.cs
@@ -58,6 +58,13 @@ namespace Solana.Unity.SDK
             throw new NotImplementedException();
         }
 
+        public override Task<byte[]> SignMessage(string message)
+        {
+            if (_internalWallet != null)
+                return _internalWallet.SignMessage(message);
+            throw new NotImplementedException();
+        }
+
         protected override Task<Account> _CreateAccount(string mnemonic = null, string password = null)
         {
             throw new NotImplementedException("Can't create a new account in phantom wallet");

--- a/Runtime/codebase/PhantomWallet.cs
+++ b/Runtime/codebase/PhantomWallet.cs
@@ -58,7 +58,7 @@ namespace Solana.Unity.SDK
             throw new NotImplementedException();
         }
 
-        public override Task<byte[]> SignMessage(string message)
+        public override Task<byte[]> SignMessage(byte[] message)
         {
             if (_internalWallet != null)
                 return _internalWallet.SignMessage(message);

--- a/Runtime/codebase/PhantomWallet/PhantomDeepLink.cs
+++ b/Runtime/codebase/PhantomWallet/PhantomDeepLink.cs
@@ -62,7 +62,7 @@ namespace Solana.Unity.SDK
             return _signedTransactionTaskCompletionSource.Task;
         }
 
-        public override Task<byte[]> SignMessage(string message)
+        public override Task<byte[]> SignMessage(byte[] message)
         {
             _signedMessageTaskCompletionSource = new TaskCompletionSource<byte[]>();
             StartSignMessage(message);
@@ -104,7 +104,7 @@ namespace Solana.Unity.SDK
             Application.OpenURL(url);
         }
 
-        private void StartSignMessage(string message)
+        private void StartSignMessage(byte[] message)
         {
             var url = Utils.CreateSignMessageDeepLink(
                 message: message,

--- a/Runtime/codebase/PhantomWallet/PhantomDeepLink.cs
+++ b/Runtime/codebase/PhantomWallet/PhantomDeepLink.cs
@@ -29,6 +29,7 @@ namespace Solana.Unity.SDK
         
         private TaskCompletionSource<Account> _loginTaskCompletionSource;
         private TaskCompletionSource<Transaction> _signedTransactionTaskCompletionSource;
+        private TaskCompletionSource<byte[]> _signedMessageTaskCompletionSource;
 
         public PhantomDeepLink(
             PhantomWalletOptions phantomWalletOptions,
@@ -59,6 +60,13 @@ namespace Solana.Unity.SDK
             _signedTransactionTaskCompletionSource = new TaskCompletionSource<Transaction>();
             StartSignTransaction(transaction);
             return _signedTransactionTaskCompletionSource.Task;
+        }
+
+        public override Task<byte[]> SignMessage(string message)
+        {
+            _signedMessageTaskCompletionSource = new TaskCompletionSource<byte[]>();
+            StartSignMessage(message);
+            return _signedMessageTaskCompletionSource.Task;
         }
 
         protected override Task<Account> _CreateAccount(string mnemonic = null, string password = null)
@@ -95,6 +103,22 @@ namespace Solana.Unity.SDK
             );
             Application.OpenURL(url);
         }
+
+        private void StartSignMessage(string message)
+        {
+            var url = Utils.CreateSignMessageDeepLink(
+                message: message,
+                phantomEncryptionPubKey: _phantomEncryptionPubKey,
+                connectionPublicKey: Encoders.Base58.EncodeData(PhantomConnectionAccountPublicKey),
+                phantomConnectionAccountPrivateKey: PhantomConnectionAccountPrivateKey,
+                redirectScheme:  _phantomWalletOptions.deeplinkUrlScheme,
+                apiVersion: _phantomWalletOptions.phantomApiVersion,
+                sessionId: _sessionId,
+                cluster: RpcCluster
+                
+            );
+            Application.OpenURL(url);
+        }
         
         #endregion        
 
@@ -109,6 +133,10 @@ namespace Solana.Unity.SDK
             else if(url.Contains("onPhantomConnected"))
             {
                 ParseConnectionSuccessful(url);
+            }
+            else if(url.Contains("messageSigned"))
+            {
+                ParseSuccessfullySignedMessage(url);
             }
         }
 
@@ -168,6 +196,25 @@ namespace Solana.Unity.SDK
             var base58TransBytes = Encoders.Base58.DecodeData(success.transaction);
             var transaction = Transaction.Deserialize(base58TransBytes);
             _signedTransactionTaskCompletionSource.SetResult(transaction);
+        }
+
+        private void ParseSuccessfullySignedMessage(string url)
+        {
+            var result = ParseQueryString(url);
+            result.TryGetValue("nonce", out var nonce);
+            result.TryGetValue("data", out var data);
+            result.TryGetValue("errorMessage", out var errorMessage);
+            if (!string.IsNullOrEmpty(errorMessage))
+            {
+                Debug.LogError($"Deeplink error: Error: {errorMessage} + Data: {data}");
+                return;
+            }
+            var k = MontgomeryCurve25519.KeyExchange(_phantomEncryptionPubKey, PhantomConnectionAccountPrivateKey);
+            var unencryptedMessage = XSalsa20Poly1305.TryDecrypt(Encoders.Base58.DecodeData(data), k, Encoders.Base58.DecodeData(nonce));
+            var bytesToUtf8String = Encoding.UTF8.GetString(unencryptedMessage);
+            var success = JsonUtility.FromJson<PhantomWalletMessageSignedSuccessfully>(bytesToUtf8String);
+            var base58SigBytes = Encoders.Base58.DecodeData(success.signature);
+            _signedMessageTaskCompletionSource.SetResult(base58SigBytes);
         }
 
         private static Dictionary<string, string> ParseQueryString(string url)

--- a/Runtime/codebase/PhantomWallet/PhantomMessagePayload.cs
+++ b/Runtime/codebase/PhantomWallet/PhantomMessagePayload.cs
@@ -1,0 +1,21 @@
+using System;
+
+// ReSharper disable once CheckNamespace
+
+namespace  Solana.Unity.SDK
+{
+    [Serializable]
+    public class PhantomMessagePayload
+    {
+        public string message;
+        public string session;
+        public string display;
+
+        public PhantomMessagePayload(string message, string session, string display)
+        {
+            this.message = message;
+            this.session = session;
+            this.display = display;
+        }
+    }
+}

--- a/Runtime/codebase/PhantomWallet/PhantomMessagePayload.meta
+++ b/Runtime/codebase/PhantomWallet/PhantomMessagePayload.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 49af8a6ffb654ff89bc8150d5e2840a7
+timeCreated: 1675333564

--- a/Runtime/codebase/PhantomWallet/PhantomWebGL.cs
+++ b/Runtime/codebase/PhantomWallet/PhantomWebGL.cs
@@ -47,10 +47,10 @@ namespace Solana.Unity.SDK
             return _signedTransactionTaskCompletionSource.Task;
         }
 
-        public override Task<byte[]> SignMessage(string message)
+        public override Task<byte[]> SignMessage(byte[] message)
         {
             _signedMessageTaskCompletionSource = new TaskCompletionSource<byte[]>();
-            ExternSignMessage(message, OnMessageSigned);
+            ExternSignMessage(Convert.ToBase64String(message), OnMessageSigned);
             return _signedMessageTaskCompletionSource.Task;
         }
         

--- a/Runtime/codebase/PhantomWallet/Utils.cs
+++ b/Runtime/codebase/PhantomWallet/Utils.cs
@@ -69,14 +69,14 @@ namespace Solana.Unity.SDK
         /// Create DeepLink URL for signing a message with Phantom and redirect to the game
         /// </summary>
         public static string CreateSignMessageDeepLink(
-            string message, 
+            byte[] message, 
             byte[] phantomEncryptionPubKey, byte[] phantomConnectionAccountPrivateKey, 
             string sessionId, string redirectScheme, string apiVersion,
             string connectionPublicKey, RpcCluster cluster)
         {
             
             var redirectUri = $"{redirectScheme}://messageSigned";
-            var base58Message = Encoders.Base58.EncodeData(Encoding.UTF8.GetBytes(message));
+            var base58Message = Encoders.Base58.EncodeData(message);
             var messagePayload = new PhantomMessagePayload(base58Message, sessionId, "utf8");
             var messagePayloadJson = JsonUtility.ToJson(messagePayload);
             var bytesJson = Encoding.UTF8.GetBytes(messagePayloadJson);

--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -246,7 +246,7 @@ namespace Solana.Unity.SDK
         }
 
         /// <inheritdoc />
-        public abstract Task<byte[]> SignMessage(string message);
+        public abstract Task<byte[]> SignMessage(byte[] message);
 
         /// <summary>
         /// Airdrop sol on wallet

--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -245,6 +245,9 @@ namespace Solana.Unity.SDK
                 Convert.ToBase64String(signedTransaction.Serialize()), preFlightCommitment: commitment);
         }
 
+        /// <inheritdoc />
+        public abstract Task<byte[]> SignMessage(string message);
+
         /// <summary>
         /// Airdrop sol on wallet
         /// </summary>

--- a/Runtime/codebase/Web3AuthWallet.cs
+++ b/Runtime/codebase/Web3AuthWallet.cs
@@ -111,10 +111,9 @@ namespace Solana.Unity.SDK
             return Task.FromResult(transaction);
         }
 
-        public override Task<byte[]> SignMessage(string message)
+        public override Task<byte[]> SignMessage(byte[] message)
         {
-            var encodedMessage = Encoding.UTF8.GetBytes(message);
-            return Task.FromResult(Account.Sign(encodedMessage));
+            return Task.FromResult(Account.Sign(message));
         }
         
         public Task<Account> LoginWithProvider(Provider provider)

--- a/Runtime/codebase/Web3AuthWallet.cs
+++ b/Runtime/codebase/Web3AuthWallet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Merkator.Tools;
 using Solana.Unity.Wallet;
@@ -108,6 +109,12 @@ namespace Solana.Unity.SDK
         {
             transaction.Sign(Account);
             return Task.FromResult(transaction);
+        }
+
+        public override Task<byte[]> SignMessage(string message)
+        {
+            var encodedMessage = Encoding.UTF8.GetBytes(message);
+            return Task.FromResult(Account.Sign(encodedMessage));
         }
         
         public Task<Account> LoginWithProvider(Provider provider)

--- a/Runtime/codebase/XNFTWallet.cs
+++ b/Runtime/codebase/XNFTWallet.cs
@@ -48,6 +48,11 @@ namespace Solana.Unity.SDK
             ExternSignTransactionXNFT(encode, OnTransactionSigned);
             return _signedTransactionTaskCompletionSource.Task;
         }
+
+        public override Task<byte[]> SignMessage(string message)
+        {
+            throw new NotImplementedException();
+        }
         
         protected override Task<Account> _CreateAccount(string mnemonic = null, string password = null)
         {

--- a/Runtime/codebase/XNFTWallet.cs
+++ b/Runtime/codebase/XNFTWallet.cs
@@ -49,7 +49,7 @@ namespace Solana.Unity.SDK
             return _signedTransactionTaskCompletionSource.Task;
         }
 
-        public override Task<byte[]> SignMessage(string message)
+        public override Task<byte[]> SignMessage(byte[] message)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Phantom signMessage method support

## Problem

We didn't have a method for requesting a message signature from a Phantom wallet. We need it to implement Phantom wallet authentication.
[https://docs.phantom.app/solana/integrating-phantom/deeplinks-ios-and-android/provider-methods/signmessage](url)
[https://docs.phantom.app/solana/integrating-phantom/extension-and-in-app-browser-web-apps/signing-a-message](url)

## Solution

Implemented signMessage method using deeplinks (for mobile) and javascript provider methods (for WebGL).