### PR TITLE
:bug: Fix WebGL signature

### DIFF
--- a/Runtime/codebase/PhantomWallet/PhantomWebGL.cs
+++ b/Runtime/codebase/PhantomWallet/PhantomWebGL.cs
@@ -67,7 +67,6 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void OnPhantomConnected(string walletPubKey)
         {
-            Debug.Log($"Wallet {walletPubKey} connected!");
             _account = new Account("", walletPubKey);
             _loginTaskCompletionSource.SetResult(_account);
         }

--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Solana.Unity.Programs;
 using Solana.Unity.Rpc;
@@ -205,32 +206,12 @@ namespace Solana.Unity.SDK
         /// <inheritdoc />
         public virtual async Task<Transaction> SignTransaction(Transaction transaction)
         {
-            Debug.Log("A");
-            foreach (var signaturePubKeyPair in transaction.Signatures)
-            {
-                Debug.Log(signaturePubKeyPair.Signature +  signaturePubKeyPair.PublicKey);
-            }
             var signatures = transaction.Signatures;
             transaction.Sign(Account);
             transaction.Signatures = DeduplicateTransactionSignatures(transaction.Signatures);
-            Debug.Log("B");
-            foreach (var signaturePubKeyPair in transaction.Signatures)
-            {
-                Debug.Log(signaturePubKeyPair.Signature +  signaturePubKeyPair.PublicKey);
-            }
             var tx = await _SignTransaction(transaction);
-            Debug.Log("C");
-            foreach (var signaturePubKeyPair in transaction.Signatures)
-            {
-                Debug.Log(signaturePubKeyPair.Signature +  signaturePubKeyPair.PublicKey);
-            }
             tx.Signatures.AddRange(signatures);
             tx.Signatures = DeduplicateTransactionSignatures(tx.Signatures);
-            Debug.Log("C");
-            foreach (var signaturePubKeyPair in transaction.Signatures)
-            {
-                Debug.Log(signaturePubKeyPair.Signature +  signaturePubKeyPair.PublicKey);
-            }
             return tx;
         }
 
@@ -319,7 +300,7 @@ namespace Solana.Unity.SDK
             var emptySgn = new byte[64];
             foreach (var sgn in signatures)
             {
-                if (sgn.Signature.Equals(emptySgn) || signaturesSet.Contains(sgn.PublicKey)) continue;
+                if (sgn.Signature.SequenceEqual(emptySgn) || signaturesSet.Contains(sgn.PublicKey)) continue;
                 signaturesSet.Add(sgn.PublicKey);
                 signaturesList.Add(sgn);
             }


### PR DESCRIPTION
# Fix WebGL signature

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | No | #49  |

## Problem

See #49 

## Solution

Equals works differently on WebGL, replaced with SequenceEqual for deduplicating correctly empty, removing the empty signature.

## Issues

Closes #49 